### PR TITLE
Add ls task in the discovery taskgraph

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -27,10 +27,17 @@ module.exports = {
             taskName: 'Task.Catalog.dmi'
         },
         {
+            label: 'catalog-ls',
+            taskName: 'Task.Catalog.ls',
+            waitOn: {
+                'catalog-dmi': 'finished'
+            }
+        },
+        {
             label: 'catalog-ohai',
             taskName: 'Task.Catalog.ohai',
             waitOn: {
-                'catalog-dmi': 'finished'
+                'catalog-ls': 'finished'
             }
         },
         {


### PR DESCRIPTION
Add  ls -l task in the node discover taskgraph. In this way, the catalog will contains ls result section.